### PR TITLE
Switch from balenaCI to flowzone

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -12,5 +12,3 @@ jobs:
     name: Flowzone
     uses: product-os/flowzone/.github/workflows/flowzone.yml@master
     secrets: inherit
-    with:
-      protect_branch: false

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -1,0 +1,16 @@
+name: Flowzone
+
+on:
+  pull_request:
+    types: [opened, synchronize, closed]
+    branches:
+      - "main"
+      - "master"
+
+jobs:
+  flowzone:
+    name: Flowzone
+    uses: product-os/flowzone/.github/workflows/flowzone.yml@master
+    secrets: inherit
+    with:
+      protect_branch: false


### PR DESCRIPTION
Adding the `flowzone.yml` file simultaneously enables [Flowzone](https://github.com/product-os/flowzone) and tells balenaCI not to bother.

This wont merge until the "protect-branch" safety is removed.